### PR TITLE
Add experimental Bun scripting sidecar

### DIFF
--- a/cmd/mc-dad-server/main.go
+++ b/cmd/mc-dad-server/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	bunpkg "github.com/KevinTCoughlin/mc-dad-server/internal/bun"
 	"github.com/KevinTCoughlin/mc-dad-server/internal/cli"
 	"github.com/KevinTCoughlin/mc-dad-server/internal/configs"
 	"github.com/KevinTCoughlin/mc-dad-server/internal/platform"
@@ -22,6 +23,7 @@ var (
 
 func main() {
 	configs.SetEmbeddedFS(embeddedFS)
+	bunpkg.SetEmbeddedFS(embeddedFS)
 
 	var app cli.CLI
 	var runner platform.CommandRunner = platform.NewOSCommandRunner()

--- a/embedded/bun/env.tmpl
+++ b/embedded/bun/env.tmpl
@@ -1,0 +1,4 @@
+RCON_PASSWORD={{.RCONPassword}}
+RCON_PORT={{.RCONPort}}
+RCON_HOST=127.0.0.1
+MC_SERVER_DIR={{.ServerDir}}

--- a/embedded/bun/package.json.tmpl
+++ b/embedded/bun/package.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "name": "mc-dad-scripts",
+  "type": "module",
+  "scripts": {
+    "start": "bun run runtime/index.ts"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
+  }
+}

--- a/embedded/bun/runtime/events.ts
+++ b/embedded/bun/runtime/events.ts
@@ -1,0 +1,35 @@
+// Typed EventEmitter with error isolation per handler.
+
+import type { McEventMap, McEventName } from "./types";
+
+type Handler<T> = (event: T) => void | Promise<void>;
+
+export class EventBus {
+  private handlers = new Map<string, Handler<any>[]>();
+
+  on<K extends McEventName>(event: K, handler: Handler<McEventMap[K]>): void {
+    const list = this.handlers.get(event) ?? [];
+    list.push(handler);
+    this.handlers.set(event, list);
+  }
+
+  off<K extends McEventName>(event: K, handler: Handler<McEventMap[K]>): void {
+    const list = this.handlers.get(event);
+    if (!list) return;
+    const idx = list.indexOf(handler);
+    if (idx >= 0) list.splice(idx, 1);
+  }
+
+  async emit<K extends McEventName>(event: K, data: McEventMap[K]): Promise<void> {
+    const list = this.handlers.get(event);
+    if (!list) return;
+
+    for (const handler of list) {
+      try {
+        await handler(data);
+      } catch (err) {
+        console.error(`[mc-scripts] Error in ${event} handler:`, err);
+      }
+    }
+  }
+}

--- a/embedded/bun/runtime/index.ts
+++ b/embedded/bun/runtime/index.ts
@@ -1,0 +1,136 @@
+// Sidecar boot: loads .env, creates the global `mc` object, loads user scripts,
+// tails the server log for events, and connects RCON.
+
+import { McServer } from "./server";
+import { readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { watch } from "node:fs";
+
+// Load .env
+const envPath = join(import.meta.dir, "..", ".env");
+const envFile = Bun.file(envPath);
+if (await envFile.exists()) {
+  const text = await envFile.text();
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+const RCON_PASSWORD = process.env.RCON_PASSWORD ?? "";
+const RCON_PORT = parseInt(process.env.RCON_PORT ?? "25575", 10);
+const RCON_HOST = process.env.RCON_HOST ?? "127.0.0.1";
+const MC_SERVER_DIR = process.env.MC_SERVER_DIR ?? resolve(import.meta.dir, "../..");
+
+// Create the mc server instance
+const mc = new McServer(RCON_HOST, RCON_PORT, RCON_PASSWORD);
+
+// Expose as global
+(globalThis as any).mc = mc;
+
+// --- Load user scripts ---
+const scriptsDir = join(import.meta.dir, "..", "scripts");
+async function loadScripts() {
+  let files: string[];
+  try {
+    const entries = await readdir(scriptsDir);
+    files = entries.filter((f) => f.endsWith(".ts") || f.endsWith(".js")).sort();
+  } catch {
+    console.log("[mc-scripts] No scripts directory found");
+    return;
+  }
+
+  for (const file of files) {
+    const path = join(scriptsDir, file);
+    try {
+      await import(path);
+      console.log(`[mc-scripts] Loaded script: ${file}`);
+    } catch (err) {
+      console.error(`[mc-scripts] Failed to load script ${file}:`, err);
+    }
+  }
+}
+
+await loadScripts();
+
+// --- Tail server log from EOF ---
+const logPath = join(MC_SERVER_DIR, "logs", "latest.log");
+
+async function tailLog() {
+  const file = Bun.file(logPath);
+  if (!(await file.exists())) {
+    console.log("[mc-scripts] Waiting for server log...");
+    // Wait for the log file to appear
+    await new Promise<void>((resolve) => {
+      const logsDir = join(MC_SERVER_DIR, "logs");
+      const interval = setInterval(async () => {
+        if (await Bun.file(logPath).exists()) {
+          clearInterval(interval);
+          resolve();
+        }
+      }, 1000);
+    });
+  }
+
+  // Read current size to start tailing from EOF
+  const stat = await file.stat();
+  let offset = stat?.size ?? 0;
+  let partial = "";
+
+  // Poll for new data
+  setInterval(async () => {
+    try {
+      const currentStat = await Bun.file(logPath).stat();
+      const currentSize = currentStat?.size ?? 0;
+
+      if (currentSize < offset) {
+        // Log was rotated/truncated, restart from beginning
+        offset = 0;
+        partial = "";
+      }
+
+      if (currentSize > offset) {
+        const f = Bun.file(logPath);
+        const chunk = await f.slice(offset, currentSize).text();
+        offset = currentSize;
+
+        const text = partial + chunk;
+        const lines = text.split("\n");
+        // Last element may be a partial line
+        partial = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (line.trim()) {
+            mc.logParser.parseLine(line);
+          }
+        }
+      }
+    } catch {
+      // Log file may be temporarily unavailable during rotation
+    }
+  }, 250);
+}
+
+tailLog();
+
+// --- Connect RCON (with retries) ---
+mc.connectRcon();
+
+// --- Graceful shutdown ---
+process.on("SIGTERM", () => {
+  mc.shutdown();
+  process.exit(0);
+});
+process.on("SIGINT", () => {
+  mc.shutdown();
+  process.exit(0);
+});
+
+console.log("[mc-scripts] Scripting sidecar ready");

--- a/embedded/bun/runtime/log-parser.ts
+++ b/embedded/bun/runtime/log-parser.ts
@@ -1,0 +1,99 @@
+// Parses Minecraft server log lines into typed events.
+
+import type { EventBus } from "./events";
+
+// Minecraft log format: [HH:MM:SS] [Thread/LEVEL]: message
+const LOG_PREFIX = /^\[\d{2}:\d{2}:\d{2}\] \[.+?\/INFO\]: /;
+
+// Player join: "PlayerName joined the game"
+const PLAYER_JOIN = /^(\w+) joined the game$/;
+
+// Player leave: "PlayerName left the game"
+const PLAYER_LEAVE = /^(\w+) left the game$/;
+
+// Chat: "<PlayerName> message"
+const CHAT = /^<(\w+)> (.+)$/;
+
+// Death messages — covers most vanilla death messages.
+// The player name is at the start, followed by a death message verb.
+const DEATH_VERBS = [
+  "was shot", "was pummeled", "was pricked", "walked into a cactus",
+  "drowned", "experienced kinetic energy", "blew up", "was blown up",
+  "was killed by", "hit the ground", "fell", "was squashed", "was squished",
+  "was stung", "was obliterated", "suffocated", "starved", "was frozen",
+  "was burnt", "was roasted", "went up in flames", "burned",
+  "tried to swim in lava", "was struck by lightning", "discovered",
+  "was fireballed", "was impaled", "didn't want to live",
+  "withered away", "died", "was slain", "was killed",
+];
+const DEATH_PATTERN = new RegExp(
+  `^(\\w+) (${DEATH_VERBS.join("|")})(.*)$`
+);
+
+// Advancement: "PlayerName has made the advancement [Advancement Name]"
+const ADVANCEMENT = /^(\w+) has made the advancement \[(.+)\]$/;
+
+// Server start: "Done (Xs)! For help, type "help""
+const SERVER_START = /^Done \([0-9.]+s\)! For help, type "help"$/;
+
+// Server stop: "Stopping the server" or "Closing Server"
+const SERVER_STOP = /^(Stopping the server|Closing Server)$/;
+
+export class LogParser {
+  constructor(private events: EventBus) {}
+
+  parseLine(line: string): void {
+    // Strip the log prefix
+    const match = line.match(LOG_PREFIX);
+    if (!match) return;
+    const msg = line.slice(match[0].length);
+
+    const now = new Date();
+
+    // Player join
+    const joinMatch = msg.match(PLAYER_JOIN);
+    if (joinMatch) {
+      this.events.emit("playerJoin", { player: joinMatch[1], timestamp: now });
+      return;
+    }
+
+    // Player leave
+    const leaveMatch = msg.match(PLAYER_LEAVE);
+    if (leaveMatch) {
+      this.events.emit("playerLeave", { player: leaveMatch[1], timestamp: now });
+      return;
+    }
+
+    // Chat
+    const chatMatch = msg.match(CHAT);
+    if (chatMatch) {
+      this.events.emit("chat", { player: chatMatch[1], message: chatMatch[2], timestamp: now });
+      return;
+    }
+
+    // Death
+    const deathMatch = msg.match(DEATH_PATTERN);
+    if (deathMatch) {
+      this.events.emit("playerDeath", { player: deathMatch[1], message: msg, timestamp: now });
+      return;
+    }
+
+    // Advancement
+    const advMatch = msg.match(ADVANCEMENT);
+    if (advMatch) {
+      this.events.emit("playerAdvancement", { player: advMatch[1], advancement: advMatch[2], timestamp: now });
+      return;
+    }
+
+    // Server start
+    if (SERVER_START.test(msg)) {
+      this.events.emit("serverStart", { timestamp: now });
+      return;
+    }
+
+    // Server stop
+    if (SERVER_STOP.test(msg)) {
+      this.events.emit("serverStop", { timestamp: now });
+    }
+  }
+}

--- a/embedded/bun/runtime/players.ts
+++ b/embedded/bun/runtime/players.ts
@@ -1,0 +1,35 @@
+// Online player tracker — maintains a list of connected players.
+
+import type { EventBus } from "./events";
+import type { PlayerInfo } from "./types";
+
+export class PlayerTracker {
+  private playerMap = new Map<string, PlayerInfo>();
+
+  constructor(events: EventBus) {
+    events.on("playerJoin", (e) => {
+      this.playerMap.set(e.player, { name: e.player, joinedAt: e.timestamp });
+    });
+
+    events.on("playerLeave", (e) => {
+      this.playerMap.delete(e.player);
+    });
+
+    // Clear player list on server stop (stale data)
+    events.on("serverStop", () => {
+      this.playerMap.clear();
+    });
+  }
+
+  get online(): PlayerInfo[] {
+    return Array.from(this.playerMap.values());
+  }
+
+  get count(): number {
+    return this.playerMap.size;
+  }
+
+  isOnline(name: string): boolean {
+    return this.playerMap.has(name);
+  }
+}

--- a/embedded/bun/runtime/rcon.ts
+++ b/embedded/bun/runtime/rcon.ts
@@ -1,0 +1,158 @@
+// RCON protocol client using Bun native TCP sockets.
+// Implements the Source RCON protocol: https://developer.valvesoftware.com/wiki/Source_RCON_Protocol
+
+import type { Socket } from "bun";
+
+const PACKET_TYPE_AUTH = 3;
+const PACKET_TYPE_AUTH_RESPONSE = 2;
+const PACKET_TYPE_COMMAND = 2;
+const PACKET_TYPE_RESPONSE = 0;
+
+interface PendingRequest {
+  resolve: (value: string) => void;
+  reject: (reason: Error) => void;
+  data: Buffer;
+}
+
+export class RconClient {
+  private socket: Socket | null = null;
+  private requestId = 0;
+  private pending = new Map<number, PendingRequest>();
+  private authenticated = false;
+  private buffer = Buffer.alloc(0);
+
+  constructor(
+    private host: string,
+    private port: number,
+    private password: string,
+  ) {}
+
+  async connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const self = this;
+      let authResolve = resolve;
+      let authReject = reject;
+
+      Bun.connect({
+        hostname: self.host,
+        port: self.port,
+        socket: {
+          open(socket) {
+            self.socket = socket;
+            // Send auth packet
+            const id = self.nextId();
+            const packet = self.encodePacket(id, PACKET_TYPE_AUTH, self.password);
+            self.pending.set(id, {
+              resolve: () => {
+                self.authenticated = true;
+                authResolve();
+              },
+              reject: authReject,
+              data: Buffer.alloc(0),
+            });
+            socket.write(packet);
+          },
+          data(socket, data) {
+            self.buffer = Buffer.concat([self.buffer, Buffer.from(data)]);
+            self.processBuffer();
+          },
+          error(socket, error) {
+            authReject(error);
+          },
+          close() {
+            self.socket = null;
+            self.authenticated = false;
+            // Reject all pending requests
+            for (const [, req] of self.pending) {
+              req.reject(new Error("RCON connection closed"));
+            }
+            self.pending.clear();
+          },
+        },
+      });
+    });
+  }
+
+  async command(cmd: string): Promise<string> {
+    if (!this.socket || !this.authenticated) {
+      throw new Error("RCON not connected");
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const id = this.nextId();
+      const packet = this.encodePacket(id, PACKET_TYPE_COMMAND, cmd);
+      this.pending.set(id, { resolve, reject, data: Buffer.alloc(0) });
+      this.socket!.write(packet);
+    });
+  }
+
+  disconnect(): void {
+    if (this.socket) {
+      this.socket.end();
+      this.socket = null;
+    }
+    this.authenticated = false;
+  }
+
+  get isConnected(): boolean {
+    return this.authenticated && this.socket !== null;
+  }
+
+  private nextId(): number {
+    return ++this.requestId;
+  }
+
+  private encodePacket(id: number, type: number, body: string): Buffer {
+    const bodyBuf = Buffer.from(body, "utf-8");
+    // Packet: 4 (size) + 4 (id) + 4 (type) + body + 2 (null terminators)
+    const size = 4 + 4 + bodyBuf.length + 2;
+    const packet = Buffer.alloc(4 + size);
+    packet.writeInt32LE(size, 0);
+    packet.writeInt32LE(id, 4);
+    packet.writeInt32LE(type, 8);
+    bodyBuf.copy(packet, 12);
+    // Two null bytes at the end (body terminator + packet terminator)
+    packet[12 + bodyBuf.length] = 0;
+    packet[13 + bodyBuf.length] = 0;
+    return packet;
+  }
+
+  private processBuffer(): void {
+    while (this.buffer.length >= 4) {
+      const size = this.buffer.readInt32LE(0);
+      const totalPacketSize = 4 + size;
+
+      if (this.buffer.length < totalPacketSize) break;
+
+      const id = this.buffer.readInt32LE(4);
+      const type = this.buffer.readInt32LE(8);
+      const body = this.buffer.subarray(12, 12 + size - 10).toString("utf-8");
+
+      this.buffer = this.buffer.subarray(totalPacketSize);
+
+      // Auth response
+      if (type === PACKET_TYPE_AUTH_RESPONSE) {
+        const req = this.pending.get(id) ?? this.pending.get(id - 1);
+        if (req) {
+          this.pending.delete(id);
+          this.pending.delete(id - 1);
+          if (id === -1) {
+            req.reject(new Error("RCON authentication failed"));
+          } else {
+            req.resolve(body);
+          }
+        }
+        continue;
+      }
+
+      // Command response
+      if (type === PACKET_TYPE_RESPONSE) {
+        const req = this.pending.get(id);
+        if (req) {
+          this.pending.delete(id);
+          req.resolve(body);
+        }
+      }
+    }
+  }
+}

--- a/embedded/bun/runtime/scheduler.ts
+++ b/embedded/bun/runtime/scheduler.ts
@@ -1,0 +1,54 @@
+// Scheduled task wrapper — interval and timeout management with cancellation.
+
+import type { ScheduledTask } from "./types";
+
+export class Scheduler {
+  private nextId = 0;
+  private tasks = new Map<number, ReturnType<typeof setInterval> | ReturnType<typeof setTimeout>>();
+
+  /** Run a function repeatedly at the given interval (ms). */
+  every(ms: number, fn: () => void | Promise<void>): ScheduledTask {
+    const id = ++this.nextId;
+    const handle = setInterval(async () => {
+      try {
+        await fn();
+      } catch (err) {
+        console.error(`[mc-scripts] Scheduled task ${id} error:`, err);
+      }
+    }, ms);
+    this.tasks.set(id, handle);
+    return { id, cancel: () => this.cancel(id) };
+  }
+
+  /** Run a function once after the given delay (ms). */
+  after(ms: number, fn: () => void | Promise<void>): ScheduledTask {
+    const id = ++this.nextId;
+    const handle = setTimeout(async () => {
+      try {
+        await fn();
+      } catch (err) {
+        console.error(`[mc-scripts] Scheduled task ${id} error:`, err);
+      }
+      this.tasks.delete(id);
+    }, ms);
+    this.tasks.set(id, handle);
+    return { id, cancel: () => this.cancel(id) };
+  }
+
+  /** Cancel a specific scheduled task. */
+  cancel(id: number): void {
+    const handle = this.tasks.get(id);
+    if (handle !== undefined) {
+      clearInterval(handle as any);
+      clearTimeout(handle as any);
+      this.tasks.delete(id);
+    }
+  }
+
+  /** Cancel all scheduled tasks. */
+  cancelAll(): void {
+    for (const [id] of this.tasks) {
+      this.cancel(id);
+    }
+  }
+}

--- a/embedded/bun/runtime/server.ts
+++ b/embedded/bun/runtime/server.ts
@@ -1,0 +1,93 @@
+// McServer — central API object exposed as the global `mc` object.
+
+import { EventBus } from "./events";
+import { RconClient } from "./rcon";
+import { LogParser } from "./log-parser";
+import { PlayerTracker } from "./players";
+import { Scheduler } from "./scheduler";
+import { WebhookServer } from "./webhooks";
+import type { McEventMap, McEventName, WebhookRoute } from "./types";
+
+export class McServer {
+  readonly events = new EventBus();
+  readonly players: PlayerTracker;
+  readonly scheduler = new Scheduler();
+  readonly webhooks = new WebhookServer();
+  readonly logParser: LogParser;
+
+  private rcon: RconClient;
+  private rconHost: string;
+  private rconPort: number;
+  private rconPassword: string;
+
+  constructor(rconHost: string, rconPort: number, rconPassword: string) {
+    this.rconHost = rconHost;
+    this.rconPort = rconPort;
+    this.rconPassword = rconPassword;
+    this.rcon = new RconClient(rconHost, rconPort, rconPassword);
+    this.players = new PlayerTracker(this.events);
+    this.logParser = new LogParser(this.events);
+  }
+
+  // --- Event API ---
+
+  on<K extends McEventName>(event: K, handler: (e: McEventMap[K]) => void | Promise<void>): void {
+    this.events.on(event, handler);
+  }
+
+  // --- RCON API ---
+
+  /** Connect to the Minecraft RCON server with retries. */
+  async connectRcon(maxRetries = 30, delayMs = 2000): Promise<boolean> {
+    for (let i = 1; i <= maxRetries; i++) {
+      try {
+        await this.rcon.connect();
+        console.log("[mc-scripts] RCON connected");
+        this.events.emit("rconReady", { timestamp: new Date() });
+        return true;
+      } catch (err) {
+        if (i < maxRetries) {
+          console.log(`[mc-scripts] RCON connection attempt ${i}/${maxRetries} failed, retrying in ${delayMs / 1000}s...`);
+          await Bun.sleep(delayMs);
+        }
+      }
+    }
+    console.warn("[mc-scripts] RCON connection failed after all retries — running without RCON");
+    return false;
+  }
+
+  /** Send a raw RCON command. */
+  async command(cmd: string): Promise<string> {
+    if (!this.rcon.isConnected) {
+      console.warn(`[mc-scripts] RCON not connected, cannot run: ${cmd}`);
+      return "";
+    }
+    return this.rcon.command(cmd);
+  }
+
+  /** Broadcast a message to all players. */
+  async say(message: string): Promise<string> {
+    return this.command(`say ${message}`);
+  }
+
+  /** Kick a player with an optional reason. */
+  async kick(player: string, reason = ""): Promise<string> {
+    const cmd = reason ? `kick ${player} ${reason}` : `kick ${player}`;
+    return this.command(cmd);
+  }
+
+  /** Teleport a player to coordinates. */
+  async tp(player: string, x: number, y: number, z: number): Promise<string> {
+    return this.command(`tp ${player} ${x} ${y} ${z}`);
+  }
+
+  // --- Lifecycle ---
+
+  /** Graceful shutdown. */
+  shutdown(): void {
+    console.log("[mc-scripts] Shutting down...");
+    this.scheduler.cancelAll();
+    this.webhooks.stop();
+    this.rcon.disconnect();
+  }
+}

--- a/embedded/bun/runtime/types.ts
+++ b/embedded/bun/runtime/types.ts
@@ -1,0 +1,70 @@
+// Shared type definitions for the mc-dad-server Bun scripting sidecar.
+
+export interface PlayerInfo {
+  name: string;
+  joinedAt: Date;
+}
+
+export interface ChatEvent {
+  player: string;
+  message: string;
+  timestamp: Date;
+}
+
+export interface PlayerJoinEvent {
+  player: string;
+  timestamp: Date;
+}
+
+export interface PlayerLeaveEvent {
+  player: string;
+  timestamp: Date;
+}
+
+export interface PlayerDeathEvent {
+  player: string;
+  message: string;
+  timestamp: Date;
+}
+
+export interface PlayerAdvancementEvent {
+  player: string;
+  advancement: string;
+  timestamp: Date;
+}
+
+export interface ServerStartEvent {
+  timestamp: Date;
+}
+
+export interface ServerStopEvent {
+  timestamp: Date;
+}
+
+export interface RconReadyEvent {
+  timestamp: Date;
+}
+
+export type McEventMap = {
+  playerJoin: PlayerJoinEvent;
+  playerLeave: PlayerLeaveEvent;
+  chat: ChatEvent;
+  playerDeath: PlayerDeathEvent;
+  playerAdvancement: PlayerAdvancementEvent;
+  serverStart: ServerStartEvent;
+  serverStop: ServerStopEvent;
+  rconReady: RconReadyEvent;
+};
+
+export type McEventName = keyof McEventMap;
+
+export interface ScheduledTask {
+  id: number;
+  cancel: () => void;
+}
+
+export interface WebhookRoute {
+  path: string;
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  handler: (req: Request) => Response | Promise<Response>;
+}

--- a/embedded/bun/runtime/webhooks.ts
+++ b/embedded/bun/runtime/webhooks.ts
@@ -1,0 +1,49 @@
+// HTTP webhook server using Bun.serve with route matching.
+
+import type { WebhookRoute } from "./types";
+
+export class WebhookServer {
+  private routes: WebhookRoute[] = [];
+  private server: ReturnType<typeof Bun.serve> | null = null;
+
+  addRoute(route: WebhookRoute): void {
+    this.routes.push(route);
+  }
+
+  start(port: number): void {
+    if (this.server) {
+      console.warn("[mc-scripts] Webhook server already running");
+      return;
+    }
+
+    this.server = Bun.serve({
+      port,
+      fetch: async (req) => {
+        const url = new URL(req.url);
+        const method = req.method.toUpperCase();
+
+        for (const route of this.routes) {
+          if (route.path === url.pathname && route.method === method) {
+            try {
+              return await route.handler(req);
+            } catch (err) {
+              console.error(`[mc-scripts] Webhook handler error (${route.method} ${route.path}):`, err);
+              return new Response("Internal Server Error", { status: 500 });
+            }
+          }
+        }
+
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    console.log(`[mc-scripts] Webhook server listening on port ${port}`);
+  }
+
+  stop(): void {
+    if (this.server) {
+      this.server.stop();
+      this.server = null;
+    }
+  }
+}

--- a/embedded/bun/scripts/example.ts
+++ b/embedded/bun/scripts/example.ts
@@ -1,0 +1,88 @@
+// Example mc-dad-server script — demonstrates the scripting API.
+// Drop .ts files in this directory and restart the server to load them.
+
+declare const mc: import("../runtime/server").McServer;
+
+// Welcome players
+mc.on("playerJoin", async (e) => {
+  await mc.say(`Welcome to the server, ${e.player}!`);
+});
+
+// Goodbye message
+mc.on("playerLeave", async (e) => {
+  await mc.say(`${e.player} has left the game. See you next time!`);
+});
+
+// Respond to !players command in chat
+mc.on("chat", async (e) => {
+  if (e.message === "!players") {
+    const players = mc.players.online;
+    if (players.length === 0) {
+      await mc.say("No players online (how are you seeing this?)");
+    } else {
+      const names = players.map((p) => p.name).join(", ");
+      await mc.say(`Online (${players.length}): ${names}`);
+    }
+  }
+});
+
+// Celebrate advancements
+mc.on("playerAdvancement", async (e) => {
+  await mc.say(`Great job ${e.player}! You earned: ${e.advancement}`);
+});
+
+// Log deaths (no chat spam)
+mc.on("playerDeath", (e) => {
+  console.log(`[death] ${e.message}`);
+});
+
+// Periodic server message every 30 minutes
+mc.scheduler.every(30 * 60_000, async () => {
+  if (mc.players.count > 0) {
+    await mc.say("Remember to save your builds! Type !players to see who's online.");
+  }
+});
+
+// Webhook: POST /api/say — broadcast a message from outside
+mc.webhooks.addRoute({
+  path: "/api/say",
+  method: "POST",
+  handler: async (req) => {
+    try {
+      const body = (await req.json()) as { message?: string };
+      if (!body.message) {
+        return new Response(JSON.stringify({ error: "missing message" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      await mc.say(body.message);
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    } catch {
+      return new Response(JSON.stringify({ error: "invalid JSON" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  },
+});
+
+// Webhook: GET /api/players — player list
+mc.webhooks.addRoute({
+  path: "/api/players",
+  method: "GET",
+  handler: () => {
+    return new Response(
+      JSON.stringify({
+        count: mc.players.count,
+        players: mc.players.online,
+      }),
+      { headers: { "Content-Type": "application/json" } },
+    );
+  },
+});
+
+// Start webhook server on port 9090
+mc.webhooks.start(9090);

--- a/embedded/bun/tsconfig.json
+++ b/embedded/bun/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"]
+  },
+  "include": ["runtime/**/*.ts", "scripts/**/*.ts"]
+}

--- a/embedded/templates/start.sh.tmpl
+++ b/embedded/templates/start.sh.tmpl
@@ -55,5 +55,21 @@ else
     )
 fi
 
+{{if .EnableBun}}
+# Bun scripting sidecar
+BUN_DIR="$SCRIPT_DIR/bun-scripts"
+if [[ -d "$BUN_DIR" ]] && command -v bun &>/dev/null; then
+    echo "Starting Bun scripting sidecar..."
+    (cd "$BUN_DIR" && bun run runtime/index.ts) &
+    BUN_PID=$!
+    cleanup() { kill "$BUN_PID" 2>/dev/null; wait "$BUN_PID" 2>/dev/null; }
+    trap cleanup EXIT INT TERM
+fi
+{{end}}
+
 echo "Starting Minecraft server with ${MEMORY} RAM (${GC_TYPE^^} GC)..."
+{{if .EnableBun}}
+"$JAVA_CMD" "${JVM_FLAGS[@]}" -jar server.jar nogui
+{{else}}
 exec "$JAVA_CMD" "${JVM_FLAGS[@]}" -jar server.jar nogui
+{{end}}

--- a/internal/bun/deploy.go
+++ b/internal/bun/deploy.go
@@ -1,0 +1,135 @@
+package bun
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/KevinTCoughlin/mc-dad-server/internal/config"
+	"github.com/KevinTCoughlin/mc-dad-server/internal/platform"
+)
+
+// DeployScripts writes the Bun scripting sidecar files to the server directory.
+// Runtime files are always overwritten (framework updates). User scripts in
+// scripts/ are preserved across re-installs.
+func DeployScripts(cfg *config.ServerConfig) error {
+	bunDir := filepath.Join(cfg.Dir, "bun-scripts")
+
+	// Always deploy runtime/ (framework files)
+	runtimeDir := filepath.Join(bunDir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		return fmt.Errorf("creating runtime dir: %w", err)
+	}
+
+	runtimeFiles := []string{
+		"runtime/types.ts",
+		"runtime/events.ts",
+		"runtime/rcon.ts",
+		"runtime/log-parser.ts",
+		"runtime/players.ts",
+		"runtime/scheduler.ts",
+		"runtime/webhooks.ts",
+		"runtime/server.ts",
+		"runtime/index.ts",
+	}
+
+	for _, name := range runtimeFiles {
+		data, err := fs.ReadFile(embeddedFS, "embedded/bun/"+name)
+		if err != nil {
+			return fmt.Errorf("reading embedded %s: %w", name, err)
+		}
+		dest := filepath.Join(bunDir, name)
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", dest, err)
+		}
+	}
+
+	// Deploy scripts/example.ts only if scripts/ directory is empty or doesn't exist
+	scriptsDir := filepath.Join(bunDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		return fmt.Errorf("creating scripts dir: %w", err)
+	}
+
+	if dirEmpty(scriptsDir) {
+		data, err := fs.ReadFile(embeddedFS, "embedded/bun/scripts/example.ts")
+		if err != nil {
+			return fmt.Errorf("reading embedded example.ts: %w", err)
+		}
+		dest := filepath.Join(scriptsDir, "example.ts")
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return fmt.Errorf("writing example.ts: %w", err)
+		}
+	}
+
+	// Deploy tsconfig.json (static)
+	data, err := fs.ReadFile(embeddedFS, "embedded/bun/tsconfig.json")
+	if err != nil {
+		return fmt.Errorf("reading embedded tsconfig.json: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(bunDir, "tsconfig.json"), data, 0o644); err != nil {
+		return fmt.Errorf("writing tsconfig.json: %w", err)
+	}
+
+	// Deploy .env from template
+	if err := deployTemplate(cfg, "embedded/bun/env.tmpl", filepath.Join(bunDir, ".env")); err != nil {
+		return fmt.Errorf("deploying .env: %w", err)
+	}
+
+	// Deploy package.json from template
+	if err := deployTemplate(cfg, "embedded/bun/package.json.tmpl", filepath.Join(bunDir, "package.json")); err != nil {
+		return fmt.Errorf("deploying package.json: %w", err)
+	}
+
+	return nil
+}
+
+// InstallDependencies runs bun install in the bun-scripts directory.
+func InstallDependencies(ctx context.Context, runner platform.CommandRunner, serverDir string) error {
+	bunDir := filepath.Join(serverDir, "bun-scripts")
+	return runner.Run(ctx, "bash", "-c", fmt.Sprintf("cd %s && bun install", bunDir))
+}
+
+// deployTemplate reads a Go template from the embedded FS, executes it with
+// config data, and writes the result to dest.
+func deployTemplate(cfg *config.ServerConfig, tmplPath, dest string) error {
+	data, err := fs.ReadFile(embeddedFS, tmplPath)
+	if err != nil {
+		return fmt.Errorf("reading template %s: %w", tmplPath, err)
+	}
+
+	tmpl, err := template.New(filepath.Base(tmplPath)).Parse(string(data))
+	if err != nil {
+		return fmt.Errorf("parsing template %s: %w", tmplPath, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, map[string]string{
+		"RCONPassword": cfg.RCONPassword,
+		"RCONPort":     "25575",
+		"ServerDir":    cfg.Dir,
+	}); err != nil {
+		return fmt.Errorf("executing template %s: %w", tmplPath, err)
+	}
+
+	return os.WriteFile(dest, buf.Bytes(), 0o644)
+}
+
+// dirEmpty returns true if the directory is empty or doesn't exist.
+func dirEmpty(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return true
+	}
+	// Ignore hidden files like .gitkeep
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), ".") {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bun/embed.go
+++ b/internal/bun/embed.go
@@ -1,0 +1,11 @@
+package bun
+
+import "io/fs"
+
+// embeddedFS is set from the cmd package which has the go:embed directive.
+var embeddedFS fs.FS
+
+// SetEmbeddedFS sets the embedded filesystem. Must be called before DeployScripts.
+func SetEmbeddedFS(fsys fs.FS) {
+	embeddedFS = fsys
+}

--- a/internal/bun/install.go
+++ b/internal/bun/install.go
@@ -1,0 +1,46 @@
+package bun
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KevinTCoughlin/mc-dad-server/internal/platform"
+	"github.com/KevinTCoughlin/mc-dad-server/internal/ui"
+)
+
+// InstallBun ensures Bun is installed on the system.
+func InstallBun(ctx context.Context, runner platform.CommandRunner, plat *platform.Platform, output *ui.UI) error {
+	output.Step("Installing Bun Runtime")
+
+	if runner.CommandExists("bun") {
+		ver, err := bunVersion(ctx, runner)
+		if err == nil {
+			output.Success("Bun %s already installed", ver)
+			return nil
+		}
+	}
+
+	output.Info("Installing Bun...")
+	err := runner.Run(ctx, "bash", "-c", "curl -fsSL https://bun.sh/install | bash")
+	if err != nil {
+		return fmt.Errorf("installing Bun: %w", err)
+	}
+
+	// Verify installation
+	ver, err := bunVersion(ctx, runner)
+	if err != nil {
+		return fmt.Errorf("Bun installation verification failed: %w", err)
+	}
+	output.Success("Bun %s installed successfully", ver)
+	return nil
+}
+
+// bunVersion returns the installed Bun version string.
+func bunVersion(ctx context.Context, runner platform.CommandRunner) (string, error) {
+	out, err := runner.RunWithOutput(ctx, "bun", "--version")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/bun/install_test.go
+++ b/internal/bun/install_test.go
@@ -1,0 +1,173 @@
+package bun
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/KevinTCoughlin/mc-dad-server/internal/config"
+	"github.com/KevinTCoughlin/mc-dad-server/internal/platform"
+)
+
+// mockKey mirrors MockRunner.key() which is unexported.
+func mockKey(name string, args ...string) string {
+	return fmt.Sprintf("%s %v", name, args)
+}
+
+func TestBunVersion(t *testing.T) {
+	runner := platform.NewMockRunner()
+	runner.OutputMap[mockKey("bun", "--version")] = []byte("1.3.0\n")
+
+	ver, err := bunVersion(context.Background(), runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != "1.3.0" {
+		t.Fatalf("expected 1.3.0, got %s", ver)
+	}
+}
+
+func TestBunVersion_NotInstalled(t *testing.T) {
+	runner := platform.NewMockRunner()
+	runner.ErrorMap[mockKey("bun", "--version")] = fmt.Errorf("bun not found")
+
+	_, err := bunVersion(context.Background(), runner)
+	if err == nil {
+		t.Fatal("expected error for missing bun")
+	}
+}
+
+func setupTestEmbedFS(t *testing.T) {
+	t.Helper()
+
+	projRoot := findProjectRoot(t)
+	embDir := filepath.Join(projRoot, "embedded")
+
+	fs := make(fstest.MapFS)
+	err := filepath.Walk(embDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(projRoot, path)
+		key := filepath.ToSlash(rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		fs[key] = &fstest.MapFile{Data: data}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embedded dir: %v", err)
+	}
+
+	embeddedFS = fs
+}
+
+func findProjectRoot(t *testing.T) string {
+	t.Helper()
+	dir, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+func TestDeployScripts(t *testing.T) {
+	setupTestEmbedFS(t)
+
+	tmpDir := t.TempDir()
+	cfg := &config.ServerConfig{
+		Dir:          tmpDir,
+		RCONPassword: "testpass123",
+	}
+
+	err := DeployScripts(cfg)
+	if err != nil {
+		t.Fatalf("DeployScripts failed: %v", err)
+	}
+
+	// Verify runtime files exist
+	runtimeFiles := []string{
+		"runtime/types.ts", "runtime/events.ts", "runtime/rcon.ts",
+		"runtime/log-parser.ts", "runtime/players.ts", "runtime/scheduler.ts",
+		"runtime/webhooks.ts", "runtime/server.ts", "runtime/index.ts",
+	}
+	for _, f := range runtimeFiles {
+		path := filepath.Join(tmpDir, "bun-scripts", f)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", f)
+		}
+	}
+
+	// Verify example script deployed
+	examplePath := filepath.Join(tmpDir, "bun-scripts", "scripts", "example.ts")
+	if _, err := os.Stat(examplePath); os.IsNotExist(err) {
+		t.Error("expected example.ts to exist")
+	}
+
+	// Verify .env has RCON password
+	envData, err := os.ReadFile(filepath.Join(tmpDir, "bun-scripts", ".env"))
+	if err != nil {
+		t.Fatalf("reading .env: %v", err)
+	}
+	if got := string(envData); !strings.Contains(got, "testpass123") {
+		t.Errorf("expected .env to contain RCON password, got: %s", got)
+	}
+
+	// Verify package.json exists
+	if _, err := os.Stat(filepath.Join(tmpDir, "bun-scripts", "package.json")); os.IsNotExist(err) {
+		t.Error("expected package.json to exist")
+	}
+
+	// Verify tsconfig.json exists
+	if _, err := os.Stat(filepath.Join(tmpDir, "bun-scripts", "tsconfig.json")); os.IsNotExist(err) {
+		t.Error("expected tsconfig.json to exist")
+	}
+}
+
+func TestDeployScripts_PreservesExistingScripts(t *testing.T) {
+	setupTestEmbedFS(t)
+
+	tmpDir := t.TempDir()
+	cfg := &config.ServerConfig{
+		Dir:          tmpDir,
+		RCONPassword: "testpass",
+	}
+
+	// Create an existing user script
+	scriptsDir := filepath.Join(tmpDir, "bun-scripts", "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userScript := filepath.Join(scriptsDir, "my-script.ts")
+	if err := os.WriteFile(userScript, []byte("// my custom script"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := DeployScripts(cfg)
+	if err != nil {
+		t.Fatalf("DeployScripts failed: %v", err)
+	}
+
+	// User script should still exist
+	if _, err := os.Stat(userScript); os.IsNotExist(err) {
+		t.Error("expected user script to be preserved")
+	}
+
+	// Example script should NOT be deployed (scripts/ not empty)
+	examplePath := filepath.Join(scriptsDir, "example.ts")
+	if _, err := os.Stat(examplePath); !os.IsNotExist(err) {
+		t.Error("expected example.ts to NOT be deployed when scripts/ has existing files")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type ServerConfig struct {
 	Whitelist    bool   `json:"whitelist"`
 	ChatFilter   bool   `json:"chat_filter"`
 	EnablePlayit bool   `json:"enable_playit"`
+	EnableBun    bool   `json:"enable_bun"`
 	Version      string `json:"version"`
 	SessionName  string `json:"session_name"`
 	MaxBackups   int    `json:"max_backups"`
@@ -49,6 +50,7 @@ func DefaultConfig() *ServerConfig {
 		Whitelist:    true,
 		ChatFilter:   true,
 		EnablePlayit: true,
+		EnableBun:    false,
 		Version:      "latest",
 		SessionName:  "minecraft",
 		MaxBackups:   5,

--- a/internal/configs/deploy.go
+++ b/internal/configs/deploy.go
@@ -129,8 +129,9 @@ func DeployStartScript(cfg *config.ServerConfig) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	return tmpl.Execute(f, map[string]string{
-		"Memory": cfg.Memory,
-		"GCType": cfg.GCType,
+	return tmpl.Execute(f, map[string]any{
+		"Memory":    cfg.Memory,
+		"GCType":    cfg.GCType,
+		"EnableBun": cfg.EnableBun,
 	})
 }

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -18,6 +18,7 @@ type InstallSummary struct {
 	GameMode     string
 	ChatFilter   bool
 	PlayitSetup  bool
+	BunEnabled   bool
 	LicenseLabel string
 	InitSystem   string
 }
@@ -93,6 +94,14 @@ func (u *UI) PrintInstallSummary(s *InstallSummary) {
 	if s.PlayitSetup {
 		fmt.Println(u.colorize(colorCyan+colorBold, "  Multiplayer (No Port Forwarding):"))
 		fmt.Printf("    Run %s and follow the setup link\n", u.Bold("playit"))
+		fmt.Println()
+	}
+
+	if s.BunEnabled {
+		fmt.Println(u.colorize(colorCyan+colorBold, "  Bun Scripting (Experimental):"))
+		fmt.Printf("    Scripts directory:  %s\n", u.Bold(s.ServerDir+"/bun-scripts/scripts/"))
+		fmt.Printf("    Example script:    %s\n", u.Bold(s.ServerDir+"/bun-scripts/scripts/example.ts"))
+		fmt.Println("    Edit scripts and restart server to apply changes")
 		fmt.Println()
 	}
 


### PR DESCRIPTION
## Summary

- Adds `--experimental-bun` flag to `mc-dad-server install` that deploys a Bun-powered TypeScript scripting sidecar alongside the Minecraft server
- Sidecar connects via RCON, tails the server log for events (join/leave/chat/death/advancement), and exposes a full scripting API: event handlers, player tracking, scheduled tasks, and HTTP webhooks
- Users drop `.ts` files into `bun-scripts/scripts/` — runtime framework is always overwritten on re-install while user scripts are preserved
- Zero npm dependencies — Bun provides TCP sockets (RCON), HTTP server (webhooks), FS ops, and TypeScript execution natively
- Bun is auto-installed if not present (BYO supported — existing `bun` on PATH is used as-is)

## User-Facing API

Scripts get a global `mc` object:

```typescript
mc.on("playerJoin", async (e) => { await mc.say(`Welcome ${e.player}!`); });
mc.on("chat", async (e) => { /* e.player, e.message */ });
await mc.command("time set day");
mc.players.online;        // PlayerInfo[]
mc.scheduler.every(30 * 60_000, async () => { await mc.say("Reminder!"); });
mc.webhooks.addRoute({ path: "/api/say", method: "POST", handler: async (req) => { ... } });
```

## Files Changed

**Go (modified):** `config.go`, `install.go`, `deploy.go`, `start.sh.tmpl`, `main.go`, `summary.go`
**Go (new):** `internal/bun/` package — `embed.go`, `install.go`, `deploy.go`, `install_test.go`
**TypeScript (new):** `embedded/bun/runtime/` (9 files), `embedded/bun/scripts/example.ts`, templates

## Test plan

- [x] `just build` — compiles with new embedded assets
- [x] `just test` — all tests pass (with `-race`)
- [x] `go vet ./...` — no issues
- [x] `just lint` — golangci-lint clean
- [ ] Install with flag: `mc-dad-server install --experimental-bun --no-playit`
- [ ] Verify `bun-scripts/` deployed with all files
- [ ] Start server, check sidecar logs for "RCON connected", "Scripting sidecar ready"
- [ ] Join server, verify welcome message from `example.ts`
- [ ] Stop server, verify clean sidecar shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)