### PR TITLE
[codex] refresh stable workflow pins and ci coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
               - 'go.sum'
               - '.golangci.yml'
               - '.github/workflows/ci.yml'
-              - 'internal/configs/embedded/**'
+              - 'internal/configs/**'
+              - 'embedded/**'
             container:
               - 'Containerfile'
               - 'entrypoint.sh'
@@ -41,7 +42,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: Tidy
@@ -50,7 +51,7 @@ jobs:
           git diff --exit-code go.mod go.sum
       - name: Vet
         run: go vet ./...
-      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      - uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
         with:
           version: v2.11.4
 
@@ -64,7 +65,7 @@ jobs:
         go-version: ["1.25.11", "1.26.4"]
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go-version }}
       - run: go test -race ./...
@@ -79,7 +80,7 @@ jobs:
         os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26.4"
       - run: go test -race ./...
@@ -90,7 +91,7 @@ jobs:
     needs: [checks, test]
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -13,9 +13,9 @@ jobs:
     name: Check Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         if: steps.check.outputs.changed == 'true'
         with:
           go-version-file: go.mod
@@ -67,7 +67,7 @@ jobs:
 
       - name: Update nightly release
         if: steps.check.outputs.changed == 'true'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@2bb465e97f322d3cb2a965294d483e0d26a67aa9 # v3.0.1
         with:
           tag_name: nightly
           name: Nightly Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           args: release --clean

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ ARG MC_VERSION=latest
 # ---------------------------------------------------------------------------
 # Stage 1: Builder — Downloads Paper JAR + plugins
 # ---------------------------------------------------------------------------
-FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS builder
+FROM debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2 AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -122,7 +122,7 @@ RUN echo "eula=true" > eula.txt
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime — Eclipse Temurin 25 JRE on Alpine Linux
 # ---------------------------------------------------------------------------
-FROM eclipse-temurin:25-jre-alpine@sha256:c707c0d18cb9e8556380719f80d96a7529d0746fbb42143893949b98ed2f8943 AS runtime
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0 AS runtime
 
 # Install bash (required by entrypoint.sh for arrays and parameter expansion)
 # hadolint ignore=DL3018


### PR DESCRIPTION
## Summary

- expand CI change detection so embedded runtime/template/config changes trigger validation
- refresh remaining low-risk GitHub Action pins and patch-level workflow versions
- pin the release and dependency-check workflows instead of leaving them on floating majors
- update the container base image digests to the latest stable published digests

## Why

`main` picked up a new Bun admin sidecar and embedded runtime/template changes after the last update PR, but the CI paths filter still referenced a nonexistent path and did not watch `embedded/**`. That meant important embedded-behavior changes could bypass checks. This PR closes that gap and brings the remaining workflow versions in line with the repo's pinned-action approach.

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }'`
- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/mc-dad-server/`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run`
- `docker build -f Containerfile -t mc-dad-server:test .`

## Notes

The container rebuild now succeeds locally. During validation, `MC_VERSION=latest` resolved to stable Paper `26.2`, the image built successfully, and the AppCDS training step completed with `AppCDS archive created successfully`.
